### PR TITLE
Close span before returing tool call message

### DIFF
--- a/ballerina/model-provider.bal
+++ b/ballerina/model-provider.bal
@@ -168,6 +168,8 @@ public isolated client class OpenAiModelProvider {
             return toolCall;
         }
         chatAssistantMessage.toolCalls = [toolCall];
+        span.addOutputMessages(chatAssistantMessage);
+        span.close();
         return chatAssistantMessage;
     }
 


### PR DESCRIPTION
## Purpose

Realted to: https://github.com/wso2/product-integrator/issues/576

## Examples

## Checklist
- [x] Linked to an issue
- [x] Updated the changelog
- [x] Checked native-image compatibility

before fix: 
<img width="1512" height="903" alt="image" src="https://github.com/user-attachments/assets/ce0ceb3a-b9fe-420d-a833-3f897386cbaf" />

after fix:
<img width="1512" height="946" alt="Screenshot 2026-04-08 at 12 13 58" src="https://github.com/user-attachments/assets/99ad1898-ec42-4403-8b7c-8dc88cc29614" />



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
Ensure tracing spans are closed on the tool-call return path in the chat function. The change records the assistant output into the observation span and explicitly closes the span before returning when the model responds with a function/tool call, aligning this path with other success and error paths to improve observability and resource management.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->