### PR TITLE
fix: update default max token count to 4096 in model provider

### DIFF
--- a/ballerina/model-provider.bal
+++ b/ballerina/model-provider.bal
@@ -19,7 +19,7 @@ import ballerina/ai.observe;
 import ballerina/jballerina.java;
 import ballerinax/azure.openai.chat;
 
-const DEFAULT_MAX_TOKEN_COUNT = 512;
+const DEFAULT_MAX_TOKEN_COUNT = 4096;
 const DEFAULT_TEMPERATURE = 0.7d;
 
 # OpenAiProvider is a client class that provides an interface for interacting with Azure-hosted OpenAI language models.


### PR DESCRIPTION
## Purpose
Increase the default maximum output token count from 512 to 4096 for the Azure OpenAI model provider.
The previous default of 512 was too restrictive for most use cases, often causing response truncation. The new value of 4096 is the safest maximum that is compatible across all Azure OpenAI model families, including GPT-3.5 Turbo, GPT-4, GPT-4 Turbo, GPT-4o, and GPT-4o mini.
Fixes:
## Examples
```ballerina
// Before: responses were limited to 512 tokens by default, causing truncation
// After: responses can now generate up to 4096 tokens by default
OpenAiModelProvider provider = check new (serviceUrl, apiKey, deploymentId, apiVersion);
