### PR TITLE
Fix/parallel tool calling support

### DIFF
--- a/ballerina/Dependencies.toml
+++ b/ballerina/Dependencies.toml
@@ -113,7 +113,7 @@ dependencies = [
 [[package]]
 org = "ballerina"
 name = "http"
-version = "2.14.10"
+version = "2.14.11"
 dependencies = [
 	{org = "ballerina", name = "auth"},
 	{org = "ballerina", name = "cache"},
@@ -146,7 +146,7 @@ modules = [
 [[package]]
 org = "ballerina"
 name = "io"
-version = "1.8.0"
+version = "1.8.1"
 dependencies = [
 	{org = "ballerina", name = "jballerina.java"},
 	{org = "ballerina", name = "lang.value"}
@@ -293,7 +293,7 @@ dependencies = [
 [[package]]
 org = "ballerina"
 name = "mime"
-version = "2.12.1"
+version = "2.12.2"
 dependencies = [
 	{org = "ballerina", name = "io"},
 	{org = "ballerina", name = "jballerina.java"},
@@ -334,7 +334,7 @@ dependencies = [
 [[package]]
 org = "ballerina"
 name = "task"
-version = "2.11.1"
+version = "2.11.2"
 dependencies = [
 	{org = "ballerina", name = "jballerina.java"},
 	{org = "ballerina", name = "time"},

--- a/ballerina/model-provider.bal
+++ b/ballerina/model-provider.bal
@@ -112,7 +112,14 @@ public isolated client class OpenAiModelProvider {
             max_tokens: self.maxTokens
         };
         if tools.length() > 0 {
-            request.functions = tools;
+            request.tools = tools.map(t => <chat:ChatCompletionTool>{
+                'type: "function",
+                'function: {
+                    name: t.name,
+                    description: t.description,
+                    parameters: t.parameters ?: {}
+                }
+            });
             span.addTools(tools);
         }
         chat:CreateChatCompletionResponse|error response =
@@ -156,18 +163,22 @@ public isolated client class OpenAiModelProvider {
 
         chat:ChatCompletionResponseMessage? message = choices[0].message;
         ai:ChatAssistantMessage chatAssistantMessage = {role: ai:ASSISTANT, content: message?.content};
-        chat:ChatCompletionFunctionCall? functionCall = message?.function_call;
-        if functionCall is () {
+        chat:ChatCompletionMessageToolCall[]? toolCalls = message?.tool_calls;
+        if toolCalls is () || toolCalls.length() == 0 {
             span.addOutputMessages(chatAssistantMessage);
             span.close();
             return chatAssistantMessage;
         }
-        ai:FunctionCall|ai:Error toolCall = self.mapToFunctionCall(functionCall);
-        if toolCall is ai:Error {
-            span.close(toolCall);
-            return toolCall;
+        ai:FunctionCall[] functionCalls = [];
+        foreach chat:ChatCompletionMessageToolCall tc in toolCalls {
+            ai:FunctionCall|ai:Error fc = self.mapToolCallToFunctionCall(tc);
+            if fc is ai:Error {
+                span.close(fc);
+                return fc;
+            }
+            functionCalls.push(fc);
         }
-        chatAssistantMessage.toolCalls = [toolCall];
+        chatAssistantMessage.toolCalls = functionCalls;
         span.addOutputMessages(chatAssistantMessage);
         span.close();
         return chatAssistantMessage;
@@ -197,33 +208,42 @@ public isolated client class OpenAiModelProvider {
             } else if message is ai:ChatAssistantMessage {
                 chat:ChatCompletionRequestMessage assistantMessage = {role: ai:ASSISTANT};
                 ai:FunctionCall[]? toolCalls = message.toolCalls;
-                if toolCalls is ai:FunctionCall[] {
-                    assistantMessage["function_call"] = {
-                        name: toolCalls[0].name,
-                        arguments: toolCalls[0].arguments.toJsonString()
-                    };
+                if toolCalls is ai:FunctionCall[] && toolCalls.length() > 0 {
+                    assistantMessage["tool_calls"] = toolCalls.map(tc => <chat:ChatCompletionMessageToolCall>{
+                        id: tc.id ?: "",
+                        'type: "function",
+                        'function: {
+                            name: tc.name,
+                            arguments: (tc.arguments ?: {}).toJsonString()
+                        }
+                    });
                 }
                 if message?.content is string {
                     assistantMessage["content"] = message?.content;
                 }
                 chatCompletionRequestMessages.push(assistantMessage);
             } else {
-                chatCompletionRequestMessages.push(message);
+                chatCompletionRequestMessages.push({
+                    "role": "tool",
+                    "tool_call_id": message.id ?: "",
+                    "content": message.content
+                });
             }
         }
         return chatCompletionRequestMessages;
     }
 
-    private isolated function mapToFunctionCall(chat:ChatCompletionFunctionCall functionCall)
+    private isolated function mapToolCallToFunctionCall(chat:ChatCompletionMessageToolCall toolCall)
     returns ai:FunctionCall|ai:LlmError {
         do {
-            json jsonArgs = check functionCall.arguments.fromJsonString();
+            json jsonArgs = check toolCall.'function.arguments.fromJsonString();
             map<json>? arguments = check jsonArgs.cloneWithType();
-            return {name: functionCall.name, arguments};
+            return {name: toolCall.'function.name, arguments, id: toolCall.id};
         } on fail error e {
-            return error ai:LlmError("Invalid or malformed arguments received in function call response.", e);
+            return error ai:LlmError("Invalid or malformed arguments received in tool call response.", e);
         }
     }
+
 
     private isolated function mapToAzureChatMessage(ai:ChatUserMessage|ai:ChatSystemMessage message)
     returns AzureChatUserMessage|AzureChatSystemMessage|ai:Error {

--- a/ballerina/tests/test_services.bal
+++ b/ballerina/tests/test_services.bal
@@ -74,3 +74,69 @@ service /llm on new http:Listener(8080) {
         };
     }
 }
+
+// Separate mock service for parallel tool call tests
+service / on new http:Listener(8081) {
+    resource function post deployments/[string deploymentId]/chat/completions(
+            string api\-version, chat:CreateChatCompletionRequest payload)
+                returns chat:CreateChatCompletionResponse|error {
+
+        chat:ChatCompletionRequestMessage[] messages = check payload.messages.ensureType();
+
+        if messages.length() == 1 {
+            // First turn: return two parallel tool calls
+            return {
+                id: "parallel-test-id",
+                'object: "chat.completion",
+                created: 1234567890,
+                model: "gpt-4o",
+                choices: [
+                    {
+                        message: {
+                            role: "assistant",
+                            tool_calls: [
+                                {
+                                    id: "call_paris_id",
+                                    'type: "function",
+                                    'function: {name: "getWeather", arguments: "{\"city\": \"Paris\"}"}
+                                },
+                                {
+                                    id: "call_tokyo_id",
+                                    'type: "function",
+                                    'function: {name: "getWeather", arguments: "{\"city\": \"Tokyo\"}"}
+                                }
+                            ]
+                        }
+                    }
+                ]
+            };
+        }
+
+        // Second turn: verify history is reconstructed correctly
+        // Assistant message must use tool_calls (not function_call)
+        json[]? toolCallsInHistory = check messages[1]["tool_calls"].ensureType();
+        test:assertTrue(toolCallsInHistory is json[], "Assistant message must use tool_calls field");
+        test:assertEquals((<json[]>toolCallsInHistory).length(), 2, "Both tool calls must be in history");
+
+        // Tool result messages must use role: "tool" with tool_call_id
+        test:assertEquals(messages[2]["role"], "tool", "First tool result must have role 'tool'");
+        test:assertEquals(messages[2]["tool_call_id"], "call_paris_id", "First result must reference call_paris_id");
+        test:assertEquals(messages[3]["role"], "tool", "Second tool result must have role 'tool'");
+        test:assertEquals(messages[3]["tool_call_id"], "call_tokyo_id", "Second result must reference call_tokyo_id");
+
+        return {
+            id: "parallel-test-id-2",
+            'object: "chat.completion",
+            created: 1234567890,
+            model: "gpt-4o",
+            choices: [
+                {
+                    message: {
+                        role: "assistant",
+                        content: "Paris is sunny at 25°C and Tokyo is rainy at 18°C."
+                    }
+                }
+            ]
+        };
+    }
+}

--- a/ballerina/tests/tests.bal
+++ b/ballerina/tests/tests.bal
@@ -25,6 +25,7 @@ const ERROR_MESSAGE = "Error occurred while attempting to parse the response fro
 const RUNTIME_SCHEMA_NOT_SUPPORTED_ERROR_MESSAGE = "Runtime schema generation is not yet supported";
 
 final OpenAiModelProvider openAiProvider = check new (SERVICE_URL, API_KEY, DEPLOYMENT_ID, API_VERSION);
+final OpenAiModelProvider parallelTestProvider = check new ("http://localhost:8081", API_KEY, DEPLOYMENT_ID, API_VERSION);
 
 string apiKey = "mock-api-key";
 string serviceUrl = "http://localhost:8080/llm";
@@ -382,4 +383,56 @@ function testGenerateMethodWithTextChunk() returns error? {
     ReviewArray result = check openAiProvider->generate(`How would you rate these text chunks out of ${maxScore}. ${chunks}. Thank you!`);
     Review r = check review.fromJsonStringWithType();
     test:assertEquals(result, [r, r]);
+}
+
+final ai:ChatCompletionFunctions[] weatherTools = [
+    {
+        name: "getWeather",
+        description: "Get the current weather for a city",
+        parameters: {
+            "type": "object",
+            "properties": {
+                "city": {"type": "string"}
+            },
+            "required": ["city"]
+        }
+    }
+];
+
+@test:Config {}
+function testParallelToolCallsInResponse() returns error? {
+    ai:ChatUserMessage userMsg = {role: ai:USER, content: "Get weather for Paris and Tokyo"};
+
+    ai:ChatAssistantMessage response = check parallelTestProvider->chat(userMsg, weatherTools);
+
+    ai:FunctionCall[]? toolCalls = response.toolCalls;
+    test:assertTrue(toolCalls is ai:FunctionCall[], "Expected tool calls in response");
+    ai:FunctionCall[] calls = <ai:FunctionCall[]>toolCalls;
+    test:assertEquals(calls.length(), 2, "Expected 2 parallel tool calls");
+    test:assertEquals(calls[0].name, "getWeather");
+    test:assertEquals(calls[0].arguments, {"city": "Paris"});
+    test:assertEquals(calls[0].id, "call_paris_id");
+    test:assertEquals(calls[1].name, "getWeather");
+    test:assertEquals(calls[1].arguments, {"city": "Tokyo"});
+    test:assertEquals(calls[1].id, "call_tokyo_id");
+}
+
+@test:Config {}
+function testParallelToolCallsHistoryReconstruction() returns error? {
+    ai:ChatMessage[] messages = [
+        <ai:ChatUserMessage>{role: ai:USER, content: "Get weather for Paris and Tokyo"},
+        <ai:ChatAssistantMessage>{
+            role: ai:ASSISTANT,
+            content: (),
+            toolCalls: [
+                {name: "getWeather", arguments: {"city": "Paris"}, id: "call_paris_id"},
+                {name: "getWeather", arguments: {"city": "Tokyo"}, id: "call_tokyo_id"}
+            ]
+        },
+        <ai:ChatFunctionMessage>{role: "function", name: "getWeather", content: "Sunny, 25°C", id: "call_paris_id"},
+        <ai:ChatFunctionMessage>{role: "function", name: "getWeather", content: "Rainy, 18°C", id: "call_tokyo_id"}
+    ];
+
+    ai:ChatAssistantMessage response = check parallelTestProvider->chat(messages, weatherTools);
+    test:assertEquals(response.content, "Paris is sunny at 25°C and Tokyo is rainy at 18°C.");
 }


### PR DESCRIPTION
## Purpose

Fixes the `OpenAiModelProvider` in `ballerinax/ai.azure` which did not support parallel tool calling. The provider was using the legacy `functions`/`function_call` API, which only allows one function call per response turn. This change migrates to the modern `tools`/`tool_calls` API, enabling the model to request multiple tool calls in a single response.

**Root cause:** The request used `request.functions` (legacy field), the response only read `message?.function_call` (single call), and the message history serialized only `toolCalls[0]` back to the model. Tool result messages were also sent with `role: "function"` instead of the required `role: "tool"`.

**Changes made:**

- **Request** — replaced `request.functions` with `request.tools` using the `ChatCompletionTool` structure required by the modern API
- **Response parsing** — replaced single `function_call` reading with iteration over the full `tool_calls` array, mapping all returned calls including their `id` field
- **History reconstruction (assistant message)** — replaced `function_call` field serialization with `tool_calls` array serialization covering all tool calls
- **History reconstruction (tool result message)** — replaced `role: "function"` with `role: "tool"` and added `tool_call_id` to correctly link each result to its originating call

> **Note:** Unit tests have been added using a mock server to verify parallel tool call parsing and history reconstruction. Live validation against a real Azure OpenAI endpoint is pending due to unavailable credentials at the time of this PR.


## Examples

**Before (single tool call only):**

User: "What is the weather and time in London?"
Model → getWeather(London)          ← only one call per turn
Client sends result
Model → getTime(London)             ← separate turn needed
Client sends result
Model → final answer

**After (parallel tool calls):**

User: "What is the weather and time in London?"
Model → getWeather(London) + getTime(London)   ← both in one response
Client sends both results back
Model → final answer

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Changes Overview

This pull request updates the `OpenAiModelProvider` to support parallel tool calling through the modern tools/tool_calls API, replacing the legacy single-call approach.

## Key Changes

**Core Implementation (`model-provider.bal`):**
- Replaces request.functions with request.tools array, using Azure's chat completion tool format
- Updates response parsing to iterate through all returned tool_calls instead of handling a single function_call
- Modifies request history serialization to properly serialize the full tool_calls array for assistant messages
- Updates tool result messages to use role "tool" with tool_call_id linkage to trace results back to their respective calls

**Test Infrastructure:**
- Adds a new mock HTTP service (port 8081) that simulates parallel tool call responses, validating both the initial request format and the correct reconstruction of message history with tool calls
- Introduces two new test functions that verify: (1) chat responses correctly parse and return multiple parallel tool calls with their IDs and arguments, and (2) message history is properly reconstructed when multiple tool results are provided

**Dependencies:**
- Updates four Ballerina package versions (http, io, mime, task) to latest patch releases

## Impact

The provider now correctly handles multiple concurrent tool calls in a single response turn, improving support for modern AI model capabilities while maintaining proper request/response formatting and message history tracking across multi-turn conversations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->