### PR TITLE
Update API Type Enum implementation

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ The new v1 GA URL is `https://<resource>.services.ai.azure.com/openai/v1`; the l
 
 | `apiType` | `serviceUrl` ends with `/v1` (v1 GA) | otherwise (legacy) |
 | --- | --- | --- |
-| `CHAT_COMPLETION` (default) | `POST {serviceUrl}/chat/completions` | `POST {legacyBase}/deployments/{deploymentId}/chat/completions?api-version=...` |
+| `CHAT_COMPLETIONS` (default) | `POST {serviceUrl}/chat/completions` | `POST {legacyBase}/deployments/{deploymentId}/chat/completions?api-version=...` |
 | `RESPONSES` | `POST {serviceUrl}/responses` | `POST {legacyBase}/responses?api-version=...` |
 
 On the legacy surface, `legacyBase` is derived from the `serviceUrl` as follows:

--- a/ballerina/README.md
+++ b/ballerina/README.md
@@ -26,7 +26,7 @@ The new v1 GA URL is `https://<resource>.services.ai.azure.com/openai/v1`; the l
 
 | `apiType` | `serviceUrl` ends with `/v1` (v1 GA) | otherwise (legacy) |
 | --- | --- | --- |
-| `CHAT_COMPLETION` (default) | `POST {serviceUrl}/chat/completions` | `POST {legacyBase}/deployments/{deploymentId}/chat/completions?api-version=...` |
+| `CHAT_COMPLETIONS` (default) | `POST {serviceUrl}/chat/completions` | `POST {legacyBase}/deployments/{deploymentId}/chat/completions?api-version=...` |
 | `RESPONSES` | `POST {serviceUrl}/responses` | `POST {legacyBase}/responses?api-version=...` |
 
 On the legacy surface, `legacyBase` is derived from the `serviceUrl` as follows:

--- a/ballerina/model-provider.bal
+++ b/ballerina/model-provider.bal
@@ -36,11 +36,11 @@ const DEFAULT_MAX_TOKEN_COUNT = 4096;
 public isolated client class OpenAiModelProvider {
     *ai:ModelProvider;
     # Generated Chat Completions connector for the v1 GA surface (`POST {serviceUrl}/chat/completions`).
-    # Created only when `apiType` is `CHAT_COMPLETION` and the `serviceUrl` targets the v1 GA surface; `()` otherwise.
+    # Created only when `apiType` is `CHAT_COMPLETIONS` and the `serviceUrl` targets the v1 GA surface; `()` otherwise.
     private final chat:Client? chatClient;
     # Raw HTTP client for the legacy Chat Completions route
     # (`POST {legacyBase}/deployments/{deploymentId}/chat/completions?api-version=...`). Created only when
-    # `apiType` is `CHAT_COMPLETION` and the `serviceUrl` targets the legacy surface; `()` otherwise. A raw client
+    # `apiType` is `CHAT_COMPLETIONS` and the `serviceUrl` targets the legacy surface; `()` otherwise. A raw client
     # (rather than the connector) is used so the request body can be serialized here and the correct token-limit
     # field (`max_tokens` vs `max_completion_tokens`) selected per api-version.
     private final http:Client? legacyChatClient;
@@ -80,7 +80,7 @@ public isolated client class OpenAiModelProvider {
     #               Set it to `()` for models that do not support this parameter (e.g. GPT-5/o-series reasoning
     #               models).
     # + reasoningEffort - Reasoning effort level for reasoning models.
-    # + apiType - The Azure OpenAI API surface to use. Defaults to `CHAT_COMPLETION`. Set to `RESPONSES` to use the
+    # + apiType - The Azure OpenAI API surface to use. Defaults to `CHAT_COMPLETIONS`. Set to `RESPONSES` to use the
     #           Responses API instead.
     # + connectionConfig - Additional HTTP connection configuration
     # + return - `nil` on successful initialization; otherwise, returns an `ai:Error`
@@ -91,7 +91,7 @@ public isolated client class OpenAiModelProvider {
             @display {label: "Maximum Tokens"} int maxTokens = DEFAULT_MAX_TOKEN_COUNT,
             @display {label: "Temperature"} decimal? temperature = (),
             @display {label: "Reasoning Effort"} ReasoningEffort? reasoningEffort = (),
-            @display {label: "API Type"} ApiType apiType = CHAT_COMPLETION,
+            @display {label: "API Type"} ApiType apiType = CHAT_COMPLETIONS,
             @display {label: "Connection Configuration"} *ConnectionConfig connectionConfig) returns ai:Error? {
 
         self.apiKey = apiKey;
@@ -134,7 +134,7 @@ public isolated client class OpenAiModelProvider {
     isolated remote function chat(ai:ChatMessage[]|ai:ChatUserMessage messages,
             ai:ChatCompletionFunctions[] tools = [],
             string? stop = ()) returns ai:ChatAssistantMessage|ai:Error {
-        if self.apiType == CHAT_COMPLETION {
+        if self.apiType == CHAT_COMPLETIONS {
             return self.chatViaChatCompletions(messages, tools, stop);
         }
         return self.chatViaResponses(messages, tools, stop);
@@ -519,7 +519,7 @@ isolated function hasPathSegment(string url) returns boolean {
 isolated function createClients(ApiType apiType, boolean isV1, string apiKey, string trimmedUrl, string legacyBase,
         ConnectionConfig connectionConfig)
         returns [chat:Client?, http:Client?, responses:Client?, http:Client?]|ai:Error {
-    if apiType == CHAT_COMPLETION {
+    if apiType == CHAT_COMPLETIONS {
         if isV1 {
             chat:Client|error chatClient = new (toChatConnectionConfig(apiKey, connectionConfig), trimmedUrl);
             if chatClient is error {

--- a/ballerina/tests/test_init.bal
+++ b/ballerina/tests/test_init.bal
@@ -23,7 +23,7 @@ import ballerina/test;
 @test:Config
 function testLegacyServiceUrlWithEmptyApiVersionFails() {
     OpenAiModelProvider|ai:Error provider =
-        new (SERVICE_URL, API_KEY, DEPLOYMENT_ID, "   ", apiType = CHAT_COMPLETION);
+        new (SERVICE_URL, API_KEY, DEPLOYMENT_ID, "   ", apiType = CHAT_COMPLETIONS);
     test:assertTrue(provider is ai:Error, "a blank api-version must be rejected for a legacy URL");
     test:assertTrue((<ai:Error>provider).message().includes("'apiVersion' argument is required"));
 }
@@ -41,7 +41,7 @@ function testLegacyResponsesUrlWithoutApiVersionFails() {
 @test:Config
 function testV1ServiceUrlIgnoresDateApiVersion() returns ai:Error? {
     OpenAiModelProvider provider =
-        check new (SERVICE_URL_V1, API_KEY, DEPLOYMENT_ID, "2024-10-21", apiType = CHAT_COMPLETION);
+        check new (SERVICE_URL_V1, API_KEY, DEPLOYMENT_ID, "2024-10-21", apiType = CHAT_COMPLETIONS);
     ai:ChatUserMessage userMsg = {role: "user", content: "Hello, how are you?"};
     ai:ChatAssistantMessage result = check provider->chat(userMsg, []);
     test:assertEquals(result.content, "This is a mock response for: Hello, how are you?");
@@ -51,7 +51,7 @@ function testV1ServiceUrlIgnoresDateApiVersion() returns ai:Error? {
 @test:Config
 function testV1ServiceUrlWithTrailingSlash() returns ai:Error? {
     OpenAiModelProvider provider =
-        check new (SERVICE_URL_V1 + "/", API_KEY, DEPLOYMENT_ID, apiType = CHAT_COMPLETION);
+        check new (SERVICE_URL_V1 + "/", API_KEY, DEPLOYMENT_ID, apiType = CHAT_COMPLETIONS);
     ai:ChatUserMessage userMsg = {role: "user", content: "Hello, how are you?"};
     ai:ChatAssistantMessage result = check provider->chat(userMsg, []);
     test:assertEquals(result.content, "This is a mock response for: Hello, how are you?");
@@ -64,7 +64,7 @@ function testV1ServiceUrlWithTrailingSlash() returns ai:Error? {
 function testLegacyServiceUrlAlreadyEndingWithOpenai() returns ai:Error? {
     OpenAiModelProvider provider =
         check new ("http://localhost:8080/llm/azureopenai/openai", API_KEY, DEPLOYMENT_ID, API_VERSION,
-            apiType = CHAT_COMPLETION);
+            apiType = CHAT_COMPLETIONS);
     ai:ChatUserMessage userMsg = {role: "user", content: "Hello, how are you?"};
     ai:ChatAssistantMessage result = check provider->chat(userMsg, []);
     test:assertEquals(result.content, "This is a mock response for: Hello, how are you?");
@@ -77,7 +77,7 @@ function testLegacyServiceUrlAlreadyEndingWithOpenai() returns ai:Error? {
 @test:Config
 function testChatV1ClientInitFailure() {
     OpenAiModelProvider|ai:Error provider =
-        new ("http://invalid host/v1", API_KEY, DEPLOYMENT_ID, apiType = CHAT_COMPLETION);
+        new ("http://invalid host/v1", API_KEY, DEPLOYMENT_ID, apiType = CHAT_COMPLETIONS);
     test:assertTrue(provider is ai:Error);
     test:assertTrue((<ai:Error>provider).message().includes("Chat Completions (v1)"));
 }
@@ -85,7 +85,7 @@ function testChatV1ClientInitFailure() {
 @test:Config
 function testChatLegacyClientInitFailure() {
     OpenAiModelProvider|ai:Error provider =
-        new ("http://invalid host", API_KEY, DEPLOYMENT_ID, API_VERSION, apiType = CHAT_COMPLETION);
+        new ("http://invalid host", API_KEY, DEPLOYMENT_ID, API_VERSION, apiType = CHAT_COMPLETIONS);
     test:assertTrue(provider is ai:Error);
     test:assertTrue((<ai:Error>provider).message().includes("Chat Completions"));
 }

--- a/ballerina/tests/test_providers.bal
+++ b/ballerina/tests/test_providers.bal
@@ -21,11 +21,11 @@
 // Chat Completions, legacy surface (a post-threshold api-version so the token limit is sent as
 // `max_completion_tokens`, which reasoning models require).
 final OpenAiModelProvider reasoningChatLegacyProvider = check new (SERVICE_URL, API_KEY, REASONING_DEPLOYMENT,
-    NEW_API_VERSION, reasoningEffort = HIGH, temperature = (), apiType = CHAT_COMPLETION);
+    NEW_API_VERSION, reasoningEffort = HIGH, temperature = (), apiType = CHAT_COMPLETIONS);
 
 // Chat Completions, v1 GA surface.
 final OpenAiModelProvider reasoningChatV1Provider = check new (SERVICE_URL_V1, API_KEY, REASONING_DEPLOYMENT,
-    reasoningEffort = MEDIUM, temperature = (), apiType = CHAT_COMPLETION);
+    reasoningEffort = MEDIUM, temperature = (), apiType = CHAT_COMPLETIONS);
 
 // Responses, legacy preview surface.
 final OpenAiModelProvider reasoningResponsesLegacyProvider = check new (SERVICE_URL, API_KEY, REASONING_DEPLOYMENT,
@@ -37,21 +37,21 @@ final OpenAiModelProvider reasoningResponsesV1Provider = check new (SERVICE_URL_
 
 // ===== Custom max-token providers (pin the exact token-limit value on the wire) =====
 final OpenAiModelProvider customTokensChatProvider = check new (SERVICE_URL, API_KEY, CUSTOM_TOKENS_DEPLOYMENT,
-    NEW_API_VERSION, maxTokens = CUSTOM_MAX_TOKENS, apiType = CHAT_COMPLETION);
+    NEW_API_VERSION, maxTokens = CUSTOM_MAX_TOKENS, apiType = CHAT_COMPLETIONS);
 
 final OpenAiModelProvider customTokensResponsesV1Provider = check new (SERVICE_URL_V1, API_KEY,
     CUSTOM_TOKENS_DEPLOYMENT, maxTokens = CUSTOM_MAX_TOKENS, apiType = RESPONSES);
 
 // ===== v1 GA `preview`/`v1` api-version opt-in providers =====
 final OpenAiModelProvider v1PreviewChatProvider = check new (SERVICE_URL_V1, API_KEY, DEPLOYMENT_ID,
-    "preview", apiType = CHAT_COMPLETION);
+    "preview", apiType = CHAT_COMPLETIONS);
 
 final OpenAiModelProvider v1OptInResponsesProvider = check new (SERVICE_URL_V1, API_KEY, DEPLOYMENT_ID,
     "v1", apiType = RESPONSES);
 
 // ===== providers whose endpoint is unreachable (drive the chat() connection-failure branches) =====
 final OpenAiModelProvider unreachableChatProvider = check new ("http://localhost:8099/nowhere", API_KEY,
-    DEPLOYMENT_ID, API_VERSION, apiType = CHAT_COMPLETION);
+    DEPLOYMENT_ID, API_VERSION, apiType = CHAT_COMPLETIONS);
 
 final OpenAiModelProvider unreachableResponsesProvider = check new ("http://localhost:8099/nowhere", API_KEY,
     DEPLOYMENT_ID, API_VERSION, apiType = RESPONSES);

--- a/ballerina/tests/test_reasoning_and_params.bal
+++ b/ballerina/tests/test_reasoning_and_params.bal
@@ -93,7 +93,7 @@ function testAllReasoningEffortValuesChatCompletions() returns ai:Error? {
     ai:ChatUserMessage userMsg = {role: "user", content: "Hello, how are you?"};
     foreach ReasoningEffort effort in efforts {
         OpenAiModelProvider provider = check new (SERVICE_URL_V1, API_KEY, REASONING_DEPLOYMENT,
-            reasoningEffort = effort, temperature = (), apiType = CHAT_COMPLETION);
+            reasoningEffort = effort, temperature = (), apiType = CHAT_COMPLETIONS);
         ai:ChatAssistantMessage result = check provider->chat(userMsg, []);
         test:assertEquals(result.content, "This is a mock response for: Hello, how are you?");
     }
@@ -165,7 +165,7 @@ function testResponsesWithStopSequenceIsIgnored() returns ai:Error? {
 @test:Config
 function testProviderWithCustomConnectionConfig() returns ai:Error? {
     OpenAiModelProvider provider = check new (SERVICE_URL, API_KEY, DEPLOYMENT_ID, API_VERSION,
-        apiType = CHAT_COMPLETION, timeout = 120, forwarded = "enable");
+        apiType = CHAT_COMPLETIONS, timeout = 120, forwarded = "enable");
     ai:ChatUserMessage userMsg = {role: "user", content: "Hello, how are you?"};
     ai:ChatAssistantMessage result = check provider->chat(userMsg, []);
     test:assertEquals(result.content, "This is a mock response for: Hello, how are you?");

--- a/ballerina/tests/tests.bal
+++ b/ballerina/tests/tests.bal
@@ -32,7 +32,7 @@ const API_KEY = "not-a-real-api-key";
 const ERROR_MESSAGE = "Error occurred while attempting to parse the response from the LLM as the expected type. Retrying and/or validating the prompt could fix the response.";
 const RUNTIME_SCHEMA_NOT_SUPPORTED_ERROR_MESSAGE = "Runtime schema generation is not yet supported";
 
-// `OpenAiModelProvider` with the default `CHAT_COMPLETION` API type — exercises the Azure OpenAI Chat Completions
+// `OpenAiModelProvider` with the default `CHAT_COMPLETIONS` API type — exercises the Azure OpenAI Chat Completions
 // API via the legacy deployment-scoped route (the service URL does not end with `/v1`), which appends
 // `?api-version=...`. This is also the default path for existing (pre-`apiType`) callers.
 final OpenAiModelProvider openAiProvider = check new (SERVICE_URL, API_KEY, DEPLOYMENT_ID, API_VERSION);
@@ -45,22 +45,22 @@ final OpenAiModelProvider responsesProvider =
 final OpenAiModelProvider responsesV1Provider =
     check new (SERVICE_URL_V1, API_KEY, DEPLOYMENT_ID, apiType = RESPONSES);
 
-// `OpenAiModelProvider` with the `CHAT_COMPLETION` API type — exercises the Azure OpenAI Chat Completions API
+// `OpenAiModelProvider` with the `CHAT_COMPLETIONS` API type — exercises the Azure OpenAI Chat Completions API
 // via the legacy deployment-scoped route.
 final OpenAiModelProvider chatCompletionProvider =
-    check new (SERVICE_URL, API_KEY, DEPLOYMENT_ID, API_VERSION, apiType = CHAT_COMPLETION);
+    check new (SERVICE_URL, API_KEY, DEPLOYMENT_ID, API_VERSION, apiType = CHAT_COMPLETIONS);
 
 // `OpenAiModelProvider` targeting the Chat Completions v1 GA surface (`/v1`-suffixed service URL, no
 // `api-version`), routed through the generated `azure.openai.chat` connector (`POST {serviceUrl}/chat/completions`).
 final OpenAiModelProvider chatCompletionV1Provider =
-    check new (SERVICE_URL_V1, API_KEY, DEPLOYMENT_ID, apiType = CHAT_COMPLETION);
+    check new (SERVICE_URL_V1, API_KEY, DEPLOYMENT_ID, apiType = CHAT_COMPLETIONS);
 
-// `CHAT_COMPLETION` providers pinned to a new (post-threshold) and an old (pre-threshold) api-version, used to
+// `CHAT_COMPLETIONS` providers pinned to a new (post-threshold) and an old (pre-threshold) api-version, used to
 // verify the token-limit field selection end-to-end through the mock's `assertChatCompletionTokenField` guard.
 final OpenAiModelProvider chatCompletionNewApiVersionProvider =
-    check new (SERVICE_URL, API_KEY, DEPLOYMENT_ID, NEW_API_VERSION, apiType = CHAT_COMPLETION);
+    check new (SERVICE_URL, API_KEY, DEPLOYMENT_ID, NEW_API_VERSION, apiType = CHAT_COMPLETIONS);
 final OpenAiModelProvider chatCompletionOldApiVersionProvider =
-    check new (SERVICE_URL, API_KEY, DEPLOYMENT_ID, OLD_API_VERSION, apiType = CHAT_COMPLETION);
+    check new (SERVICE_URL, API_KEY, DEPLOYMENT_ID, OLD_API_VERSION, apiType = CHAT_COMPLETIONS);
 
 string apiKey = "mock-api-key";
 // The embeddings deployment-scoped route is hosted by the legacy Azure OpenAI mock service.
@@ -774,7 +774,7 @@ function testResponsesV1ChatWithTools() returns ai:Error? {
     test:assertEquals((<ai:FunctionCall[]>toolCalls)[0].arguments, {"city": "London"});
 }
 
-// ===== Chat Completions API (`apiType = CHAT_COMPLETION`) tests =====
+// ===== Chat Completions API (`apiType = CHAT_COMPLETIONS`) tests =====
 // These hit the deployment-scoped Azure OpenAI Chat Completions endpoint:
 //   {legacyBase}/deployments/{deploymentId}/chat/completions?api-version=...
 
@@ -930,7 +930,7 @@ function testChatCompletionV1GenerateMethod() returns ai:Error? {
 @test:Config
 function testLegacyServiceUrlWithoutApiVersionFails() returns error? {
     OpenAiModelProvider|ai:Error provider =
-        new (SERVICE_URL, API_KEY, DEPLOYMENT_ID, apiType = CHAT_COMPLETION);
+        new (SERVICE_URL, API_KEY, DEPLOYMENT_ID, apiType = CHAT_COMPLETIONS);
     test:assertTrue(provider is ai:Error, "expected init to fail when api-version is omitted for a legacy URL");
     test:assertTrue((<ai:Error>provider).message().includes("'apiVersion' argument is required"),
             "unexpected error message: " + (<ai:Error>provider).message());

--- a/ballerina/types.bal
+++ b/ballerina/types.bal
@@ -83,18 +83,18 @@ public type ConnectionConfig record {|
 #
 # | `apiType` | `serviceUrl` ends with `/v1` (v1 GA) | otherwise (legacy) |
 # | --- | --- | --- |
-# | `CHAT_COMPLETION` | `POST {serviceUrl}/chat/completions` via the `azure.openai.chat` connector | `POST {legacyBase}/deployments/{deploymentId}/chat/completions?api-version={apiVersion}` |
+# | `CHAT_COMPLETIONS` | `POST {serviceUrl}/chat/completions` via the `azure.openai.chat` connector | `POST {legacyBase}/deployments/{deploymentId}/chat/completions?api-version={apiVersion}` |
 # | `RESPONSES` | `POST {serviceUrl}/responses` via the `azure.openai.responses` connector | `POST {legacyBase}/responses?api-version={apiVersion}` |
 #
 # On the legacy surface `legacyBase` is the `serviceUrl` completed with `/openai` when it is a bare origin
 # (e.g. `https://<resource>.openai.azure.com`) and used verbatim when it already carries a path (e.g. an API
 # Management base path).
+@display {label: "OpenAI API Type"}
 public enum ApiType {
-    # Use the Azure OpenAI **Chat Completions API**. This is the default and preserves the behaviour of
-    # earlier releases of this module.
-    CHAT_COMPLETION,
-    # Use the Azure OpenAI **Responses API**.
-    RESPONSES
+    # Use the OpenAI Chat Completions API (`/chat/completions`)
+    CHAT_COMPLETIONS = "chat_completions",
+    # Use the OpenAI Responses API (`/responses`)
+    RESPONSES = "responses"
 }
 
 # Reasoning effort level for reasoning models (`gpt-5`/`o`-series).

--- a/native/src/main/java/io/ballerina/lib/ai.azure/Generator.java
+++ b/native/src/main/java/io/ballerina/lib/ai.azure/Generator.java
@@ -28,7 +28,7 @@ import io.ballerina.runtime.api.values.BTypedesc;
  * This class provides the native function to generate a response from an Azure AI model.
  *
  * <p>The {@code OpenAiModelProvider} selects its API surface through the {@code apiType} field. When it is
- * {@code CHAT_COMPLETION} (the default), the request is routed to the Chat Completions API; otherwise it is
+ * {@code CHAT_COMPLETIONS} (the default), the request is routed to the Chat Completions API; otherwise it is
  * routed to the Responses API. Each path in turn selects the v1 GA connector or the legacy raw HTTP client based
  * on the {@code useV1} flag.
  *
@@ -37,7 +37,7 @@ import io.ballerina.runtime.api.values.BTypedesc;
 public class Generator {
     private static final Module MODULE = new Module("ballerinax", "ai.azure", "1");
 
-    private static final String CHAT_COMPLETION = "CHAT_COMPLETION";
+    private static final String CHAT_COMPLETIONS = "chat_completions";
 
     private static final String API_TYPE = "apiType";
     private static final String CHAT_CLIENT = "chatClient";
@@ -56,7 +56,7 @@ public class Generator {
     public static Object generate(Environment env, BObject modelProvider,
                                   BObject prompt, BTypedesc expectedResponseTypedesc) {
         Object apiType = modelProvider.get(StringUtils.fromString(API_TYPE));
-        if (apiType instanceof BString apiTypeStr && CHAT_COMPLETION.equals(apiTypeStr.getValue())) {
+        if (apiType instanceof BString apiTypeStr && CHAT_COMPLETIONS.equals(apiTypeStr.getValue())) {
             return generateViaChatCompletions(env, modelProvider, prompt, expectedResponseTypedesc);
         }
         return generateViaResponses(env, modelProvider, prompt, expectedResponseTypedesc);


### PR DESCRIPTION
Update API Type Enum implementation

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary

- Renamed `ApiType.CHAT_COMPLETION` to `ApiType.CHAT_COMPLETIONS`.
- Updated Azure OpenAI provider defaults, routing logic, documentation, and tests.
- Added explicit string values for `CHAT_COMPLETIONS` and `RESPONSES`.
- Added test coverage for legacy and v1 Chat Completions routes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->