### PR TITLE
Clarify Overview so the Central summary distinguishes ai.azure

### DIFF
--- a/ballerina/README.md
+++ b/ballerina/README.md
@@ -1,8 +1,6 @@
 ## Overview
 
-Azure OpenAI Service provides access to OpenAI's powerful language models within the Microsoft Azure platform.
-
-The Azure OpenAI connector offers APIs for connecting with Azure OpenAI Large Language Models (LLMs), enabling the integration of advanced conversational AI, text generation, and language processing capabilities into applications.
+The `ai.azure` module provides Azure OpenAI-backed `ModelProvider` and `EmbeddingProvider` implementations for the [`ballerina/ai`](https://central.ballerina.io/ballerina/ai/latest) agent framework. Use it to drive Azure-hosted OpenAI chat models (GPT-4o, GPT-4, o-series) and embedding models from Ballerina AI agents and RAG pipelines, rather than calling the Azure OpenAI REST API directly (for which use `azure.openai.chat`).
 
 ### Key Features
 


### PR DESCRIPTION
### Purpose

The first paragraph of the package Overview is what Ballerina Central stores as the package **summary**, and that summary is the `description` the Ballerina Copilot **library-search tool** returns to the agent when it selects a library. Across the OpenAI / Azure OpenAI / `ai.*` packages this first paragraph was a generic vendor blurb, so their summaries were nearly identical and an agent could not reliably tell them apart (e.g. an agent-framework model provider vs a direct REST connector).

### Change

Rewrite the Overview's first paragraph into a single, **capability-first** sentence that states what this module uniquely is — grounded in its actual API and `Ballerina.toml` type keywords — so the summary alone disambiguates it from its siblings. The now-redundant generic second paragraph is merged away. **Key Features** and everything below are untouched; `Module.md` is synced where present.

> Draft: opening for wording review. Part of a coordinated pass to disambiguate the AI/LLM package summaries surfaced by Copilot library search.

🤖 Generated with [Claude Code](https://claude.com/claude-code)